### PR TITLE
fix #20: create Procfile for automatic migration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bundle exec rake db:migrate


### PR DESCRIPTION
Procfile を作成し、以下を記載
```
release: bundle exec rake db:migrate
```

これにより、master ブランチがマージされると、 `bundle exec rake db:migrate` が自動実行されるようになります。