### PR TITLE
【Add】開発用のGem導入

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,25 @@
+begin
+  require 'hirb'
+rescue LoadError
+  # Missing goodies, bummer
+end
+
+if defined? Hirb
+  # Slightly dirty hack to fully support in-session Hirb.disable/enable toggling
+  Hirb::View.instance_eval do
+    def enable_output_method
+      @output_method = true
+      @old_print = Pry.config.print
+      Pry.config.print = proc do |*args|
+        Hirb::View.view_or_page_output(args[1]) || @old_print.call(*args)
+      end
+    end
+
+    def disable_output_method
+      Pry.config.print = @old_print
+      @output_method = nil
+    end
+  end
+
+  Hirb.enable
+end

--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,12 @@ gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 
 group :development, :test do
-  gem 'byebug'
-  gem 'web-console', '~> 2.0'
   gem 'spring'
+  gem 'web-console', '~> 2.0'
+  gem 'byebug'
+  gem 'pry-rails'
+  gem 'hirb'
+  gem 'hirb-unicode'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -79,6 +80,10 @@ GEM
       temple (>= 0.8.0)
       tilt
     hashie (3.5.5)
+    hirb (0.7.3)
+    hirb-unicode (0.0.5)
+      hirb (~> 0.5)
+      unicode-display_width (~> 0.1.1)
     i18n (0.8.4)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -115,6 +120,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -148,6 +154,12 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.19.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (2.0.5)
     rack (1.6.8)
     rack-pjax (1.0.0)
@@ -204,6 +216,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.1)
@@ -224,6 +237,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (0.1.1)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -241,6 +255,8 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   devise
   dotenv-rails
+  hirb
+  hirb-unicode
   jbuilder (~> 2.0)
   jquery-rails
   letter_opener_web
@@ -249,6 +265,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   pg (= 0.19.0)
+  pry-rails
   rails (= 4.2.3)
   rails_admin
   sass-rails (~> 5.0)


### PR DESCRIPTION
#59 開発用のGem導入 
pry-rails hirb hirb-unicode 追加
pry導入時にコンソールでhirbが使えるように.pryrcに作成・記述

hirbについて
　rails c　で　Hirb.enable と入力　→　User.all　などの出力が整形されます。