### PR TITLE
【FIX】bookmarks.controllerをcreate,destroyに限定（その他を削除）、routes.rbのbookmark設定を少し修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,75 +1,18 @@
 class BookmarksController < ApplicationController
-  # before_action :authenticate_user!
-  before_action :set_bookmark, only: [:show, :edit, :update, :destroy]
+  before_action :set_question
 
-  # GET /bookmarks
-  # GET /bookmarks.json
-  def index
-    @bookmarks = Bookmark.all
-  end
-
-  # GET /bookmarks/1
-  # GET /bookmarks/1.json
-  def show
-  end
-
-  # GET /bookmarks/new
-  def new
-    @bookmark = Bookmark.new
-  end
-
-  # GET /bookmarks/1/edit
-  # def edit
-  # end
-
-  # POST /bookmarks
-  # POST /bookmarks.json
   def create
-    @bookmark = Bookmark.new(bookmark_params)
-
-    respond_to do |format|
-      if @bookmark.save
-        format.html { redirect_to @bookmark, notice: 'お気に入りに登録しました。' }
-        format.json { render :show, status: :created, location: @bookmark }
-      else
-        format.html { render :new }
-        format.json { render json: @bookmark.errors, status: :unprocessable_entity }
-      end
-    end
+    @bookmark = current_user.bookmarks.build(question_id: @question.id)
+    @question = @bookmark.question
   end
 
-  # PATCH/PUT /bookmarks/1
-  # PATCH/PUT /bookmarks/1.json
-  # def update
-  #  respond_to do |format|
-  #    if @bookmark.update(bookmark_params)
-  #      format.html { redirect_to @bookmark, notice: 'Bookmark was successfully updated.' }
-  #      format.json { render :show, status: :ok, location: @bookmark }
-  #    else
-  #      format.html { render :edit }
-  #      format.json { render json: @bookmark.errors, status: :unprocessable_entity }
-  #    end
-  #  end
-  #end
-
-  # DELETE /bookmarks/1
-  # DELETE /bookmarks/1.json
   def destroy
+    @bookmark = Bookmark.find(params[:id])
     @bookmark.destroy
-    respond_to do |format|
-      format.html { redirect_to bookmarks_url, notice: 'お気に入りを削除しました。' }
-      format.json { head :no_content }
-    end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_bookmark
-      @bookmark = Bookmark.find(params[:id])
-    end
-
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def bookmark_params
-      params.require(:bookmark).permit(:question_id, :user_id)
+    def set_question
+      @question = Question.find(params[:bookmark][:question_id])
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   root 'top#index'
   resources 'questions'
   resources 'tags'
-  resources 'bookmarks'
+  resources 'bookmarks', only: [:create, :destroy]
   resources 'users', only: [:index, :show]
 
   if Rails.env.development?


### PR DESCRIPTION
#56 

- [ ] bookmarks.controllerのアクションをcreate,destroyに限定。

- [ ] before_actionにset_questionを設定し、Questionができてからお気に入り機能をcreate,destroyできるように設定。

- [ ] routes.rbのbookmarksのルートを修正（onlyを追加）